### PR TITLE
Fix continuously touch end events and ensuretouchEnd if no scroll

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,7 +47,7 @@ void MainWindow::checkEvents()
   }
 
   if(!touchEnabled)
-       touchState.event = TE_NONE;
+    touchState.event = TE_NONE;
 
   if (touchState.event == TE_DOWN) {
     onTouchStart(touchState.x + scrollPositionX, touchState.y + scrollPositionY);
@@ -81,7 +81,9 @@ void MainWindow::checkEvents()
       touchState.lastDeltaY = 0;
 
     onTouchSlide(touchState.x, touchState.y, touchState.startX, touchState.startY, touchState.lastDeltaX, touchState.lastDeltaY);
-    slidingWindow = nullptr;
+  } else if (touchState.event == TE_SLIDE_END && slidingWindow == nullptr) {
+    onTouchEnd(touchState.startX + scrollPositionX, touchState.startY + scrollPositionY);
+    touchState.event = TE_NONE;
   }
 #endif
 


### PR DESCRIPTION
* minor changes to touch and slide processing.  set event to TE_NONE so you don't continuously get touch end events.
also make sure you get touchEnd if you slid but there is no sliding window (e.g. no scroll happened)

* revert slide operations back to their original state

* fix merge issue

* one more try and it should be right now

Co-authored-by: kkoenig1@optonline.com <kkoenig1@optonline.com>